### PR TITLE
Python3 fix.

### DIFF
--- a/canvas.py
+++ b/canvas.py
@@ -2,7 +2,10 @@
 # Authors: Massimo Di Pierro & Laurent Peuch
 # License: 3-clause BSD (c) 2012
 
-from cStringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_agg import FigureCanvasAgg


### PR DESCRIPTION
A user of Shoebot accidentally installed canvas under python3, unfortunately it broke because of the use of cStringIO.

Either change it to the above so it works on both versions of consider upgrading entirely to Python3.